### PR TITLE
feat: translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/es.json
+++ b/languages/es.json
@@ -9,7 +9,7 @@
 			"n": "No es necesario probar",
 			"a": "Archivado - Para archivar o no disponible",
 			"u": "Estado Desconocido - El Paquete no se encuentra en el listado oficial",
-			"c": ""
+			"c": "Marcado como compatible por el desarrollador en el manifiesto"
 		},
 		"loading": "Cargando…",
 		"selectVersion": "Verificando compatibilidad con:",
@@ -42,8 +42,8 @@
 		"projectURL": "URL del Proyecto",
 		"showCompatible": "Mostrar sólo Paquetes compatibles",
 		"resetFilters": "Reiniciar Filtros",
-		"unknownAuthor": "",
-		"percentageTooltip": "",
+		"unknownAuthor": "Autor Desconocido",
+		"percentageTooltip": "El porcentaje de paquetes visibles que está listo para ser usado con la versión core seleccionada.",
 		"reminder": ""
 	}
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -7,7 +7,7 @@
 			"b": "Imposible de probar",
 			"g": "El Paquete funciona sin problemas o hay una nueva versión disponible",
 			"n": "No es necesario probar",
-			"a": "Archivado - Para archivar o no disponible",
+			"a": "Archivado - El paquete puede funcionar, pero no es mantenido activamente",
 			"u": "Estado Desconocido - El Paquete no se encuentra en el listado oficial",
 			"c": "Marcado como compatible por el desarrollador en el manifiesto"
 		},
@@ -44,6 +44,6 @@
 		"resetFilters": "Reiniciar Filtros",
 		"unknownAuthor": "Autor Desconocido",
 		"percentageTooltip": "El porcentaje de paquetes visibles que está listo para ser usado con la versión core seleccionada.",
-		"reminder": ""
+		"reminder": "Favor de recordar que los desarrolladores de módulos y sistemas son voluntarios, tienen sus propias vidas y agendas. Solo porque no hayan actualizado el contenido aun, no significa que no lo vayan a hacer nunca. Es importante tener paciencia. Los desarrolladores son humanos también."
 	}
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Module Compatibility Checker/main](https://weblate.foundryvtt-hub.com/projects/mcc/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/mcc/-/main/horizontal-auto.svg)