### PR TITLE
chore: update for released TRL 0.0.22 / svelte-standard 0.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,24 +7,24 @@
 			"name": "mcc",
 			"license": "MIT",
 			"dependencies": {
-				"@typhonjs-fvtt/runtime": "^0.0.21",
-				"@typhonjs-fvtt/svelte-standard": "^0.0.17",
+				"@typhonjs-fvtt/runtime": "^0.0.22",
+				"@typhonjs-fvtt/svelte-standard": "^0.0.18",
 				"chart.js": "^3.9.1",
-				"svelte": "^3.52.0",
-				"svelte-preprocess": "^4.10.7"
+				"svelte": "^3.55.0"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^3.18.0",
 				"@typhonjs-fvtt/eslint-config-foundry.js": "^0.8.0",
 				"eslint": "^8.26.0",
 				"eslint-config-arcanist": "^1.5.0",
-				"vite": "^3.2.2"
+				"svelte-preprocess": "^5.0.1",
+				"vite": "^4.1.1"
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.18.0.tgz",
-			"integrity": "sha512-ehKOJVLMeR+tZkYhWEaLYQxl0TaIZu/kE86HF3/RidR8Xv5LuQxpbh+XXAoKVqsaphWLhIgBhgnlN5HGdheXSQ==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.19.0.tgz",
+			"integrity": "sha512-0FRcsz7Ea3jT+gc5gKPIYciykm1bbAaTpygdzpCwGt0RL+V83zWnYN30NWDW4rIHj/FHtz+MIuBKS61C8l7AzQ==",
 			"dev": true
 		},
 		"node_modules/@csstools/postcss-cascade-layers": {
@@ -278,25 +278,39 @@
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
+			"integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
 			"engines": {
-				"node": "^12 || ^14 || >=16"
+				"node": "^14 || ^16 || >=18"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
-				"postcss": "^8.2",
+				"postcss": "^8.4",
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
+		"node_modules/@es-joy/jsdoccomment": {
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+			"dev": true,
+			"dependencies": {
+				"comment-parser": "1.3.1",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "~3.1.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
+			}
+		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
-			"integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
 			"cpu": [
 				"arm"
 			],
@@ -308,10 +322,145 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+			"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+			"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+			"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+			"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+			"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+			"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+			"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+			"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+			"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
-			"integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -323,16 +472,181 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+			"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+			"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+			"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+			"cpu": [
+				"riscv64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+			"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+			"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+			"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+			"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+			"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -347,9 +661,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -379,69 +693,10 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
-			}
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -524,28 +779,23 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.1.0.tgz",
-			"integrity": "sha512-cFRfEdztubtj1c/rYh7ArK7XCfFJn6wG6+J8/e9amFsKtEJILovoBrK0/mxt1AjPQg0vaX+fHPKvhx+q8mTPaQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
+			"integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
-				"svelte-hmr": "^0.15.0"
+				"magic-string": "^0.27.0",
+				"svelte-hmr": "^0.15.1",
+				"vitefu": "^0.2.3"
 			},
 			"engines": {
 				"node": "^14.18.0 || >= 16"
 			},
 			"peerDependencies": {
-				"diff-match-patch": "^1.0.5",
-				"svelte": "^3.44.0",
-				"vite": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"diff-match-patch": {
-					"optional": true
-				}
+				"svelte": "^3.54.0",
+				"vite": "^4.0.0"
 			}
 		},
 		"node_modules/@trysound/sax": {
@@ -562,9 +812,9 @@
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+			"version": "18.13.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"node_modules/@types/pug": {
 			"version": "2.0.6",
@@ -591,12 +841,12 @@
 			"dev": true
 		},
 		"node_modules/@typhonjs-fvtt/runtime": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/runtime/-/runtime-0.0.21.tgz",
-			"integrity": "sha512-+SmJo6C1RPTzdt6KBj3Wowyj556XNf/0Gb6+Wlhvk28Aac9RuBRW37TYSniGrXB5dLjOw3yuMb5FplWzctCUKg==",
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/runtime/-/runtime-0.0.22.tgz",
+			"integrity": "sha512-H2qaisFGmKTF4yv/2XBIKUdwkU0WR880hz18ibAlzsuyTFoxEo6xbjCenZ7Mr4qXER4SMwGNj6XphdEMUK57tA==",
 			"dependencies": {
 				"@rollup/plugin-node-resolve": "^15",
-				"@sveltejs/vite-plugin-svelte": "^1",
+				"@sveltejs/vite-plugin-svelte": "^2",
 				"autoprefixer": "^10",
 				"cssnano": "^5",
 				"postcss": "^8",
@@ -604,24 +854,24 @@
 				"sass": "^1"
 			},
 			"peerDependencies": {
-				"svelte": "^3.50.0",
-				"svelte-preprocess": "^4.10.0",
-				"vite": "^3"
+				"svelte": ">=3.55.0",
+				"svelte-preprocess": ">=5.0.0",
+				"vite": ">=4.1.0"
 			}
 		},
 		"node_modules/@typhonjs-fvtt/svelte-standard": {
-			"version": "0.0.17",
-			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.17.tgz",
-			"integrity": "sha512-W4fHwKKeiO/F3vUv1hTr1V6yE8xwmQMUYxKv9bHe8p0nBbVWz3j+912mJ4wJiQyq0PEltfiRcE1XtJoOklc8IQ==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.18.tgz",
+			"integrity": "sha512-PvExGZ7CC8fYWhRdVEYCPNvaAa3uN+jdPbEgbgzwv1EPmFBwZI7BMEfDX0P5ub2Dk9D7BEMjoVi8JarwMjfnFQ==",
 			"engines": {
 				"node": ">=14.18"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-			"devOptional": true,
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -679,9 +929,9 @@
 			}
 		},
 		"node_modules/anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -767,9 +1017,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.21.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -781,10 +1031,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001449",
+				"electron-to-chromium": "^1.4.284",
+				"node-releases": "^2.0.8",
+				"update-browserslist-db": "^1.0.10"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -800,13 +1050,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
@@ -840,9 +1083,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001429",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-			"integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==",
+			"version": "1.0.30001451",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+			"integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -941,6 +1184,15 @@
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/comment-parser": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -1060,9 +1312,9 @@
 			}
 		},
 		"node_modules/cssdb": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.2.tgz",
-			"integrity": "sha512-Vm4b6P/PifADu0a76H0DKRNVWq3Rq9xa/Nx6oEMUBJlwTUuZoZ3dkZxo8Gob3UEL53Cq+Ma1GBgISed6XEBs3w==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.4.1.tgz",
+			"integrity": "sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/csstools"
@@ -1186,9 +1438,9 @@
 			"dev": true
 		},
 		"node_modules/deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1265,9 +1517,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+			"version": "1.4.290",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.290.tgz",
+			"integrity": "sha512-3uIkNYprKqAixFqANvs7K3zacGz6iVIMcGG1M/7hMn6Gvzxe52Xg//wRUds7GPv2uouF7EZ4Sh51fLDw+aBkHw=="
 		},
 		"node_modules/entities": {
 			"version": "2.2.0",
@@ -1283,9 +1535,9 @@
 			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
-			"integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -1294,328 +1546,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.12",
-				"@esbuild/linux-loong64": "0.15.12",
-				"esbuild-android-64": "0.15.12",
-				"esbuild-android-arm64": "0.15.12",
-				"esbuild-darwin-64": "0.15.12",
-				"esbuild-darwin-arm64": "0.15.12",
-				"esbuild-freebsd-64": "0.15.12",
-				"esbuild-freebsd-arm64": "0.15.12",
-				"esbuild-linux-32": "0.15.12",
-				"esbuild-linux-64": "0.15.12",
-				"esbuild-linux-arm": "0.15.12",
-				"esbuild-linux-arm64": "0.15.12",
-				"esbuild-linux-mips64le": "0.15.12",
-				"esbuild-linux-ppc64le": "0.15.12",
-				"esbuild-linux-riscv64": "0.15.12",
-				"esbuild-linux-s390x": "0.15.12",
-				"esbuild-netbsd-64": "0.15.12",
-				"esbuild-openbsd-64": "0.15.12",
-				"esbuild-sunos-64": "0.15.12",
-				"esbuild-windows-32": "0.15.12",
-				"esbuild-windows-64": "0.15.12",
-				"esbuild-windows-arm64": "0.15.12"
-			}
-		},
-		"node_modules/esbuild-android-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
-			"integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
-			"integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
-			"integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
-			"integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
-			"integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
-			"integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
-			"integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
-			"integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
-			"integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
-			"integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
-			"integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
-			"cpu": [
-				"mips64el"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
-			"integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
-			"cpu": [
-				"ppc64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
-			"integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
-			"cpu": [
-				"riscv64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-s390x": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
-			"integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
-			"cpu": [
-				"s390x"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-netbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
-			"integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
-			"integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
-			"integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
-			"integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
-			"integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
-			"integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
+				"@esbuild/android-arm": "0.16.17",
+				"@esbuild/android-arm64": "0.16.17",
+				"@esbuild/android-x64": "0.16.17",
+				"@esbuild/darwin-arm64": "0.16.17",
+				"@esbuild/darwin-x64": "0.16.17",
+				"@esbuild/freebsd-arm64": "0.16.17",
+				"@esbuild/freebsd-x64": "0.16.17",
+				"@esbuild/linux-arm": "0.16.17",
+				"@esbuild/linux-arm64": "0.16.17",
+				"@esbuild/linux-ia32": "0.16.17",
+				"@esbuild/linux-loong64": "0.16.17",
+				"@esbuild/linux-mips64el": "0.16.17",
+				"@esbuild/linux-ppc64": "0.16.17",
+				"@esbuild/linux-riscv64": "0.16.17",
+				"@esbuild/linux-s390x": "0.16.17",
+				"@esbuild/linux-x64": "0.16.17",
+				"@esbuild/netbsd-x64": "0.16.17",
+				"@esbuild/openbsd-x64": "0.16.17",
+				"@esbuild/sunos-x64": "0.16.17",
+				"@esbuild/win32-arm64": "0.16.17",
+				"@esbuild/win32-ia32": "0.16.17",
+				"@esbuild/win32-x64": "0.16.17"
 			}
 		},
 		"node_modules/escalade": {
@@ -1639,13 +1591,13 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+			"version": "8.33.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+			"integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint/eslintrc": "^1.4.1",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -1664,7 +1616,7 @@
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -1695,13 +1647,14 @@
 			}
 		},
 		"node_modules/eslint-config-arcanist": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-arcanist/-/eslint-config-arcanist-1.5.0.tgz",
-			"integrity": "sha512-DPatREedHOrAfApXieyvQPfrw49rfYEFLl/aiVU9/F0OSVwXfFteX/qQFw/FRF2jBt2sFjStBFL2y9TZS8T3mQ==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/eslint-config-arcanist/-/eslint-config-arcanist-1.5.3.tgz",
+			"integrity": "sha512-Ywdd9IJnLNEWS9xfakqZeNt00MyKxSQX76ydwWAnv7JkW8KEDu1PD/nds+omfbDu12FZaaLTqhuWqOPhVbD7sg==",
 			"dev": true,
 			"dependencies": {
 				"@typhonjs-fvtt/eslint-config-foundry.js": "^0.8.0",
 				"eslint-config-prettier": "^8.5.0",
+				"eslint-plugin-jsdoc": "^39.6.4",
 				"eslint-plugin-json": "^3.1.0"
 			},
 			"peerDependencies": {
@@ -1709,15 +1662,36 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc": {
+			"version": "39.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.8.0.tgz",
+			"integrity": "sha512-ZwGmk0jJoJD/NILeDRBKrpq/PCgddUdATjeU5JGTqTzKsOWfeaHOnaAwZjuOh7T8EB4hSoZ/9pR4+Qns2ldQVg==",
+			"dev": true,
+			"dependencies": {
+				"@es-joy/jsdoccomment": "~0.36.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
+				"escape-string-regexp": "^4.0.0",
+				"esquery": "^1.4.0",
+				"semver": "^7.3.8",
+				"spdx-expression-parse": "^3.0.1"
+			},
+			"engines": {
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-json": {
@@ -1783,9 +1757,9 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -1865,9 +1839,9 @@
 			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1998,9 +1972,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -2044,18 +2018,18 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/immutable": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-			"integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
+			"integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w=="
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -2108,9 +2082,9 @@
 			}
 		},
 		"node_modules/is-builtin-module": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
 			"dependencies": {
 				"builtin-modules": "^3.3.0"
 			},
@@ -2180,10 +2154,14 @@
 			"dev": true
 		},
 		"node_modules/js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-			"dev": true
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+			"integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2195,6 +2173,15 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdoc-type-pratt-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/json-schema-traverse": {
@@ -2281,12 +2268,24 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
 		},
-		"node_modules/magic-string": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+			"integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.13"
 			},
 			"engines": {
 				"node": ">=12"
@@ -2358,9 +2357,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -2515,9 +2514,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+			"version": "8.4.21",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2686,9 +2685,9 @@
 			}
 		},
 		"node_modules/postcss-custom-properties": {
-			"version": "12.1.10",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.10.tgz",
-			"integrity": "sha512-U3BHdgrYhCrwTVcByFHs9EOBoqcKq4Lf3kXwbTi4hhq0qWhl/pDWq2THbv/ICX/Fl9KqeHBb8OVrTf2OaYF07A==",
+			"version": "12.1.11",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.11.tgz",
+			"integrity": "sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -2910,36 +2909,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2"
-			}
-		},
-		"node_modules/postcss-load-config": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"lilconfig": "^2.0.5",
-				"yaml": "^1.10.2"
-			},
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			},
-			"peerDependencies": {
-				"postcss": ">=8.0.9",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"postcss": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/postcss-logical": {
@@ -3201,9 +3170,9 @@
 			}
 		},
 		"node_modules/postcss-opacity-percentage": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
-			"integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
+			"integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
 			"funding": [
 				{
 					"type": "kofi",
@@ -3216,6 +3185,9 @@
 			],
 			"engines": {
 				"node": "^12 || ^14 || >=16"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2"
 			}
 		},
 		"node_modules/postcss-ordered-values": {
@@ -3278,11 +3250,11 @@
 			}
 		},
 		"node_modules/postcss-preset-env": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.2.tgz",
-			"integrity": "sha512-rSMUEaOCnovKnwc5LvBDHUDzpGP+nrUeWZGWt9M72fBvckCi45JmnJigUr4QG4zZeOHmOCNCZnd2LKDvP++ZuQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.3.tgz",
+			"integrity": "sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==",
 			"dependencies": {
-				"@csstools/postcss-cascade-layers": "^1.1.0",
+				"@csstools/postcss-cascade-layers": "^1.1.1",
 				"@csstools/postcss-color-function": "^1.1.1",
 				"@csstools/postcss-font-format-keywords": "^1.0.1",
 				"@csstools/postcss-hwb-function": "^1.0.2",
@@ -3296,19 +3268,19 @@
 				"@csstools/postcss-text-decoration-shorthand": "^1.0.0",
 				"@csstools/postcss-trigonometric-functions": "^1.0.2",
 				"@csstools/postcss-unset-value": "^1.0.2",
-				"autoprefixer": "^10.4.11",
-				"browserslist": "^4.21.3",
+				"autoprefixer": "^10.4.13",
+				"browserslist": "^4.21.4",
 				"css-blank-pseudo": "^3.0.3",
 				"css-has-pseudo": "^3.0.4",
 				"css-prefers-color-scheme": "^6.0.3",
-				"cssdb": "^7.0.1",
+				"cssdb": "^7.1.0",
 				"postcss-attribute-case-insensitive": "^5.0.2",
 				"postcss-clamp": "^4.1.0",
 				"postcss-color-functional-notation": "^4.2.4",
 				"postcss-color-hex-alpha": "^8.0.4",
 				"postcss-color-rebeccapurple": "^7.1.1",
 				"postcss-custom-media": "^8.0.2",
-				"postcss-custom-properties": "^12.1.9",
+				"postcss-custom-properties": "^12.1.10",
 				"postcss-custom-selectors": "^6.0.3",
 				"postcss-dir-pseudo-class": "^6.0.5",
 				"postcss-double-position-gradients": "^3.1.2",
@@ -3417,9 +3389,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.10",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3472,9 +3444,9 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -3574,14 +3546,15 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.79.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.14.0.tgz",
+			"integrity": "sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==",
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.18.0",
+				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -3633,9 +3606,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
-			"integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.0.tgz",
+			"integrity": "sha512-PiMJcP33DdKtZ/1jSjjqVIKihoDc6yWmYr9K/4r3fVVIEDAluD0q7XZiRKrNJcPK3qkLRF/79DND1H5q1LBjgg==",
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -3646,6 +3619,21 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -3670,17 +3658,17 @@
 			}
 		},
 		"node_modules/sorcery": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-			"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
+			"integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
 			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.14",
 				"buffer-crc32": "^0.2.5",
 				"minimist": "^1.2.0",
-				"sander": "^0.5.0",
-				"sourcemap-codec": "^1.3.0"
+				"sander": "^0.5.0"
 			},
 			"bin": {
-				"sorcery": "bin/index.js"
+				"sorcery": "bin/sorcery"
 			}
 		},
 		"node_modules/source-map": {
@@ -3699,21 +3687,27 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"optional": true,
-			"peer": true,
+		"node_modules/spdx-exceptions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"node_modules/sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+			"dev": true
 		},
 		"node_modules/stable": {
 			"version": "0.1.8",
@@ -3795,17 +3789,17 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-			"integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+			"version": "3.55.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
+			"integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.0.tgz",
-			"integrity": "sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
+			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
@@ -3814,20 +3808,20 @@
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "4.10.7",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
+			"integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@types/pug": "^2.0.4",
-				"@types/sass": "^1.16.0",
-				"detect-indent": "^6.0.0",
-				"magic-string": "^0.25.7",
-				"sorcery": "^0.10.0",
+				"@types/pug": "^2.0.6",
+				"@types/sass": "^1.43.1",
+				"detect-indent": "^6.1.0",
+				"magic-string": "^0.27.0",
+				"sorcery": "^0.11.0",
 				"strip-indent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 9.11.2"
+				"node": ">= 14.10.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.10.2",
@@ -3838,7 +3832,7 @@
 				"pug": "^3.0.0",
 				"sass": "^1.26.8",
 				"stylus": "^0.55.0",
-				"sugarss": "^2.0.0",
+				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
 				"svelte": "^3.23.0",
 				"typescript": "^3.9.5 || ^4.0.0"
 			},
@@ -3850,9 +3844,6 @@
 					"optional": true
 				},
 				"less": {
-					"optional": true
-				},
-				"node-sass": {
 					"optional": true
 				},
 				"postcss": {
@@ -3878,14 +3869,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-preprocess/node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
 		"node_modules/svgo": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -3905,32 +3888,6 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
-		},
-		"node_modules/terser": {
-			"version": "5.15.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/terser/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
@@ -4013,14 +3970,14 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/vite": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
-			"integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
+			"integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
 			"dependencies": {
-				"esbuild": "^0.15.9",
-				"postcss": "^8.4.18",
+				"esbuild": "^0.16.14",
+				"postcss": "^8.4.21",
 				"resolve": "^1.22.1",
-				"rollup": "^2.79.1"
+				"rollup": "^3.10.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -4032,6 +3989,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
+				"@types/node": ">= 14",
 				"less": "*",
 				"sass": "*",
 				"stylus": "*",
@@ -4039,6 +3997,9 @@
 				"terser": "^5.4.0"
 			},
 			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
 				"less": {
 					"optional": true
 				},
@@ -4052,6 +4013,19 @@
 					"optional": true
 				},
 				"terser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitefu": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
+			"integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
+			"peerDependencies": {
+				"vite": "^3.0.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"vite": {
 					"optional": true
 				}
 			}
@@ -4070,9 +4044,9 @@
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
-			"integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+			"integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
 			"dev": true
 		},
 		"node_modules/vscode-languageserver-types": {
@@ -4088,9 +4062,9 @@
 			"dev": true
 		},
 		"node_modules/vscode-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.6.tgz",
-			"integrity": "sha512-fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+			"integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
 			"dev": true
 		},
 		"node_modules/which": {
@@ -4122,6 +4096,12 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/yaml": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -4145,9 +4125,9 @@
 	},
 	"dependencies": {
 		"@cloudflare/workers-types": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.18.0.tgz",
-			"integrity": "sha512-ehKOJVLMeR+tZkYhWEaLYQxl0TaIZu/kE86HF3/RidR8Xv5LuQxpbh+XXAoKVqsaphWLhIgBhgnlN5HGdheXSQ==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.19.0.tgz",
+			"integrity": "sha512-0FRcsz7Ea3jT+gc5gKPIYciykm1bbAaTpygdzpCwGt0RL+V83zWnYN30NWDW4rIHj/FHtz+MIuBKS61C8l7AzQ==",
 			"dev": true
 		},
 		"@csstools/postcss-cascade-layers": {
@@ -4266,33 +4246,164 @@
 			"requires": {}
 		},
 		"@csstools/selector-specificity": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
+			"integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
 			"requires": {}
 		},
+		"@es-joy/jsdoccomment": {
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+			"dev": true,
+			"requires": {
+				"comment-parser": "1.3.1",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "~3.1.0"
+			}
+		},
 		"@esbuild/android-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
-			"integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+			"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+			"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+			"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+			"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+			"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+			"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+			"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+			"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+			"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
-			"integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+			"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+			"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+			"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+			"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+			"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+			"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+			"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+			"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
 			"optional": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -4301,9 +4412,9 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -4323,60 +4434,10 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-			"optional": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"optional": true,
-			"peer": true
-		},
-		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"optional": true,
-			"peer": true
-		},
-		"@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-			"optional": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"optional": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-			"optional": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
-			}
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -4428,15 +4489,16 @@
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.1.0.tgz",
-			"integrity": "sha512-cFRfEdztubtj1c/rYh7ArK7XCfFJn6wG6+J8/e9amFsKtEJILovoBrK0/mxt1AjPQg0vaX+fHPKvhx+q8mTPaQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
+			"integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
 			"requires": {
 				"debug": "^4.3.4",
 				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
-				"svelte-hmr": "^0.15.0"
+				"magic-string": "^0.27.0",
+				"svelte-hmr": "^0.15.1",
+				"vitefu": "^0.2.3"
 			}
 		},
 		"@trysound/sax": {
@@ -4450,9 +4512,9 @@
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
 		},
 		"@types/node": {
-			"version": "18.11.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+			"version": "18.13.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"@types/pug": {
 			"version": "2.0.6",
@@ -4479,12 +4541,12 @@
 			"dev": true
 		},
 		"@typhonjs-fvtt/runtime": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/runtime/-/runtime-0.0.21.tgz",
-			"integrity": "sha512-+SmJo6C1RPTzdt6KBj3Wowyj556XNf/0Gb6+Wlhvk28Aac9RuBRW37TYSniGrXB5dLjOw3yuMb5FplWzctCUKg==",
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/runtime/-/runtime-0.0.22.tgz",
+			"integrity": "sha512-H2qaisFGmKTF4yv/2XBIKUdwkU0WR880hz18ibAlzsuyTFoxEo6xbjCenZ7Mr4qXER4SMwGNj6XphdEMUK57tA==",
 			"requires": {
 				"@rollup/plugin-node-resolve": "^15",
-				"@sveltejs/vite-plugin-svelte": "^1",
+				"@sveltejs/vite-plugin-svelte": "^2",
 				"autoprefixer": "^10",
 				"cssnano": "^5",
 				"postcss": "^8",
@@ -4493,15 +4555,15 @@
 			}
 		},
 		"@typhonjs-fvtt/svelte-standard": {
-			"version": "0.0.17",
-			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.17.tgz",
-			"integrity": "sha512-W4fHwKKeiO/F3vUv1hTr1V6yE8xwmQMUYxKv9bHe8p0nBbVWz3j+912mJ4wJiQyq0PEltfiRcE1XtJoOklc8IQ=="
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@typhonjs-fvtt/svelte-standard/-/svelte-standard-0.0.18.tgz",
+			"integrity": "sha512-PvExGZ7CC8fYWhRdVEYCPNvaAa3uN+jdPbEgbgzwv1EPmFBwZI7BMEfDX0P5ub2Dk9D7BEMjoVi8JarwMjfnFQ=="
 		},
 		"acorn": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-			"devOptional": true
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -4538,9 +4600,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -4598,27 +4660,20 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"version": "4.21.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001400",
-				"electron-to-chromium": "^1.4.251",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.9"
+				"caniuse-lite": "^1.0.30001449",
+				"electron-to-chromium": "^1.4.284",
+				"node-releases": "^2.0.8",
+				"update-browserslist-db": "^1.0.10"
 			}
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
-		},
-		"buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"optional": true,
-			"peer": true
 		},
 		"builtin-modules": {
 			"version": "3.3.0",
@@ -4643,9 +4698,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001429",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-			"integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
+			"version": "1.0.30001451",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+			"integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -4711,6 +4766,12 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+		},
+		"comment-parser": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -4783,9 +4844,9 @@
 			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
 		},
 		"cssdb": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.2.tgz",
-			"integrity": "sha512-Vm4b6P/PifADu0a76H0DKRNVWq3Rq9xa/Nx6oEMUBJlwTUuZoZ3dkZxo8Gob3UEL53Cq+Ma1GBgISed6XEBs3w=="
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.4.1.tgz",
+			"integrity": "sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ=="
 		},
 		"cssesc": {
 			"version": "3.0.0",
@@ -4867,9 +4928,9 @@
 			"dev": true
 		},
 		"deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
 		},
 		"detect-indent": {
 			"version": "6.1.0",
@@ -4919,9 +4980,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.284",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+			"version": "1.4.290",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.290.tgz",
+			"integrity": "sha512-3uIkNYprKqAixFqANvs7K3zacGz6iVIMcGG1M/7hMn6Gvzxe52Xg//wRUds7GPv2uouF7EZ4Sh51fLDw+aBkHw=="
 		},
 		"entities": {
 			"version": "2.2.0",
@@ -4934,153 +4995,33 @@
 			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
 		},
 		"esbuild": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
-			"integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
 			"requires": {
-				"@esbuild/android-arm": "0.15.12",
-				"@esbuild/linux-loong64": "0.15.12",
-				"esbuild-android-64": "0.15.12",
-				"esbuild-android-arm64": "0.15.12",
-				"esbuild-darwin-64": "0.15.12",
-				"esbuild-darwin-arm64": "0.15.12",
-				"esbuild-freebsd-64": "0.15.12",
-				"esbuild-freebsd-arm64": "0.15.12",
-				"esbuild-linux-32": "0.15.12",
-				"esbuild-linux-64": "0.15.12",
-				"esbuild-linux-arm": "0.15.12",
-				"esbuild-linux-arm64": "0.15.12",
-				"esbuild-linux-mips64le": "0.15.12",
-				"esbuild-linux-ppc64le": "0.15.12",
-				"esbuild-linux-riscv64": "0.15.12",
-				"esbuild-linux-s390x": "0.15.12",
-				"esbuild-netbsd-64": "0.15.12",
-				"esbuild-openbsd-64": "0.15.12",
-				"esbuild-sunos-64": "0.15.12",
-				"esbuild-windows-32": "0.15.12",
-				"esbuild-windows-64": "0.15.12",
-				"esbuild-windows-arm64": "0.15.12"
+				"@esbuild/android-arm": "0.16.17",
+				"@esbuild/android-arm64": "0.16.17",
+				"@esbuild/android-x64": "0.16.17",
+				"@esbuild/darwin-arm64": "0.16.17",
+				"@esbuild/darwin-x64": "0.16.17",
+				"@esbuild/freebsd-arm64": "0.16.17",
+				"@esbuild/freebsd-x64": "0.16.17",
+				"@esbuild/linux-arm": "0.16.17",
+				"@esbuild/linux-arm64": "0.16.17",
+				"@esbuild/linux-ia32": "0.16.17",
+				"@esbuild/linux-loong64": "0.16.17",
+				"@esbuild/linux-mips64el": "0.16.17",
+				"@esbuild/linux-ppc64": "0.16.17",
+				"@esbuild/linux-riscv64": "0.16.17",
+				"@esbuild/linux-s390x": "0.16.17",
+				"@esbuild/linux-x64": "0.16.17",
+				"@esbuild/netbsd-x64": "0.16.17",
+				"@esbuild/openbsd-x64": "0.16.17",
+				"@esbuild/sunos-x64": "0.16.17",
+				"@esbuild/win32-arm64": "0.16.17",
+				"@esbuild/win32-ia32": "0.16.17",
+				"@esbuild/win32-x64": "0.16.17"
 			}
-		},
-		"esbuild-android-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
-			"integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
-			"integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
-			"integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
-			"integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
-			"integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
-			"integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
-			"integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
-			"integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
-			"integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
-			"integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
-			"integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
-			"integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
-			"integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
-			"integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
-			"integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
-			"integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
-			"integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
-			"integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
-			"integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
-			"integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
-			"optional": true
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -5094,13 +5035,13 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+			"version": "8.33.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+			"integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint/eslintrc": "^1.4.1",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -5119,7 +5060,7 @@
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -5141,22 +5082,38 @@
 			}
 		},
 		"eslint-config-arcanist": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-arcanist/-/eslint-config-arcanist-1.5.0.tgz",
-			"integrity": "sha512-DPatREedHOrAfApXieyvQPfrw49rfYEFLl/aiVU9/F0OSVwXfFteX/qQFw/FRF2jBt2sFjStBFL2y9TZS8T3mQ==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/eslint-config-arcanist/-/eslint-config-arcanist-1.5.3.tgz",
+			"integrity": "sha512-Ywdd9IJnLNEWS9xfakqZeNt00MyKxSQX76ydwWAnv7JkW8KEDu1PD/nds+omfbDu12FZaaLTqhuWqOPhVbD7sg==",
 			"dev": true,
 			"requires": {
 				"@typhonjs-fvtt/eslint-config-foundry.js": "^0.8.0",
 				"eslint-config-prettier": "^8.5.0",
+				"eslint-plugin-jsdoc": "^39.6.4",
 				"eslint-plugin-json": "^3.1.0"
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
 			"dev": true,
 			"requires": {}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "39.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.8.0.tgz",
+			"integrity": "sha512-ZwGmk0jJoJD/NILeDRBKrpq/PCgddUdATjeU5JGTqTzKsOWfeaHOnaAwZjuOh7T8EB4hSoZ/9pR4+Qns2ldQVg==",
+			"dev": true,
+			"requires": {
+				"@es-joy/jsdoccomment": "~0.36.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
+				"escape-string-regexp": "^4.0.0",
+				"esquery": "^1.4.0",
+				"semver": "^7.3.8",
+				"spdx-expression-parse": "^3.0.1"
+			}
 		},
 		"eslint-plugin-json": {
 			"version": "3.1.0",
@@ -5202,9 +5159,9 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -5266,9 +5223,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -5361,9 +5318,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
@@ -5395,15 +5352,15 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true
 		},
 		"immutable": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-			"integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
+			"integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -5444,9 +5401,9 @@
 			}
 		},
 		"is-builtin-module": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
 			"requires": {
 				"builtin-modules": "^3.3.0"
 			}
@@ -5495,9 +5452,9 @@
 			"dev": true
 		},
 		"js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+			"integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
 			"dev": true
 		},
 		"js-yaml": {
@@ -5508,6 +5465,12 @@
 			"requires": {
 				"argparse": "^2.0.1"
 			}
+		},
+		"jsdoc-type-pratt-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -5578,12 +5541,21 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
 		},
-		"magic-string": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.8"
+				"yallist": "^4.0.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+			"integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.4.13"
 			}
 		},
 		"mdn-data": {
@@ -5634,9 +5606,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -5743,9 +5715,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"postcss": {
-			"version": "8.4.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+			"version": "8.4.21",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
 			"requires": {
 				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
@@ -5830,9 +5802,9 @@
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "12.1.10",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.10.tgz",
-			"integrity": "sha512-U3BHdgrYhCrwTVcByFHs9EOBoqcKq4Lf3kXwbTi4hhq0qWhl/pDWq2THbv/ICX/Fl9KqeHBb8OVrTf2OaYF07A==",
+			"version": "12.1.11",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.11.tgz",
+			"integrity": "sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==",
 			"requires": {
 				"postcss-value-parser": "^4.2.0"
 			}
@@ -5943,17 +5915,6 @@
 			"requires": {
 				"@csstools/postcss-progressive-custom-properties": "^1.1.0",
 				"postcss-value-parser": "^4.2.0"
-			}
-		},
-		"postcss-load-config": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
-			"optional": true,
-			"peer": true,
-			"requires": {
-				"lilconfig": "^2.0.5",
-				"yaml": "^1.10.2"
 			}
 		},
 		"postcss-logical": {
@@ -6106,9 +6067,10 @@
 			}
 		},
 		"postcss-opacity-percentage": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
-			"integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
+			"integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
+			"requires": {}
 		},
 		"postcss-ordered-values": {
 			"version": "5.1.3",
@@ -6142,11 +6104,11 @@
 			}
 		},
 		"postcss-preset-env": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.2.tgz",
-			"integrity": "sha512-rSMUEaOCnovKnwc5LvBDHUDzpGP+nrUeWZGWt9M72fBvckCi45JmnJigUr4QG4zZeOHmOCNCZnd2LKDvP++ZuQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.3.tgz",
+			"integrity": "sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==",
 			"requires": {
-				"@csstools/postcss-cascade-layers": "^1.1.0",
+				"@csstools/postcss-cascade-layers": "^1.1.1",
 				"@csstools/postcss-color-function": "^1.1.1",
 				"@csstools/postcss-font-format-keywords": "^1.0.1",
 				"@csstools/postcss-hwb-function": "^1.0.2",
@@ -6160,19 +6122,19 @@
 				"@csstools/postcss-text-decoration-shorthand": "^1.0.0",
 				"@csstools/postcss-trigonometric-functions": "^1.0.2",
 				"@csstools/postcss-unset-value": "^1.0.2",
-				"autoprefixer": "^10.4.11",
-				"browserslist": "^4.21.3",
+				"autoprefixer": "^10.4.13",
+				"browserslist": "^4.21.4",
 				"css-blank-pseudo": "^3.0.3",
 				"css-has-pseudo": "^3.0.4",
 				"css-prefers-color-scheme": "^6.0.3",
-				"cssdb": "^7.0.1",
+				"cssdb": "^7.1.0",
 				"postcss-attribute-case-insensitive": "^5.0.2",
 				"postcss-clamp": "^4.1.0",
 				"postcss-color-functional-notation": "^4.2.4",
 				"postcss-color-hex-alpha": "^8.0.4",
 				"postcss-color-rebeccapurple": "^7.1.1",
 				"postcss-custom-media": "^8.0.2",
-				"postcss-custom-properties": "^12.1.9",
+				"postcss-custom-properties": "^12.1.10",
 				"postcss-custom-selectors": "^6.0.3",
 				"postcss-dir-pseudo-class": "^6.0.5",
 				"postcss-double-position-gradients": "^3.1.2",
@@ -6237,9 +6199,9 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.10",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -6274,9 +6236,9 @@
 			"dev": true
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -6331,9 +6293,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.79.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.14.0.tgz",
+			"integrity": "sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==",
 			"requires": {
 				"fsevents": "~2.3.2"
 			}
@@ -6369,13 +6331,22 @@
 			}
 		},
 		"sass": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
-			"integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.0.tgz",
+			"integrity": "sha512-PiMJcP33DdKtZ/1jSjjqVIKihoDc6yWmYr9K/4r3fVVIEDAluD0q7XZiRKrNJcPK3qkLRF/79DND1H5q1LBjgg==",
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
+			}
+		},
+		"semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"shebang-command": {
@@ -6394,14 +6365,14 @@
 			"dev": true
 		},
 		"sorcery": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-			"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
+			"integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
 			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.4.14",
 				"buffer-crc32": "^0.2.5",
 				"minimist": "^1.2.0",
-				"sander": "^0.5.0",
-				"sourcemap-codec": "^1.3.0"
+				"sander": "^0.5.0"
 			}
 		},
 		"source-map": {
@@ -6414,21 +6385,27 @@
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
 		},
-		"source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"optional": true,
-			"peer": true,
+		"spdx-exceptions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		"spdx-license-ids": {
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+			"dev": true
 		},
 		"stable": {
 			"version": "0.1.8",
@@ -6482,37 +6459,27 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
 		},
 		"svelte": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-			"integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ=="
+			"version": "3.55.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
+			"integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ=="
 		},
 		"svelte-hmr": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.0.tgz",
-			"integrity": "sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
+			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "4.10.7",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
+			"integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
 			"requires": {
-				"@types/pug": "^2.0.4",
-				"@types/sass": "^1.16.0",
-				"detect-indent": "^6.0.0",
-				"magic-string": "^0.25.7",
-				"sorcery": "^0.10.0",
+				"@types/pug": "^2.0.6",
+				"@types/sass": "^1.43.1",
+				"detect-indent": "^6.1.0",
+				"magic-string": "^0.27.0",
+				"sorcery": "^0.11.0",
 				"strip-indent": "^3.0.0"
-			},
-			"dependencies": {
-				"magic-string": {
-					"version": "0.25.9",
-					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-					"requires": {
-						"sourcemap-codec": "^1.4.8"
-					}
-				}
 			}
 		},
 		"svgo": {
@@ -6527,28 +6494,6 @@
 				"csso": "^4.2.0",
 				"picocolors": "^1.0.0",
 				"stable": "^0.1.8"
-			}
-		},
-		"terser": {
-			"version": "5.15.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
-			"optional": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true,
-					"peer": true
-				}
 			}
 		},
 		"text-table": {
@@ -6604,16 +6549,22 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"vite": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
-			"integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
+			"integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
 			"requires": {
-				"esbuild": "^0.15.9",
+				"esbuild": "^0.16.14",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.18",
+				"postcss": "^8.4.21",
 				"resolve": "^1.22.1",
-				"rollup": "^2.79.1"
+				"rollup": "^3.10.0"
 			}
+		},
+		"vitefu": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
+			"integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
+			"requires": {}
 		},
 		"vscode-json-languageservice": {
 			"version": "4.2.1",
@@ -6629,9 +6580,9 @@
 			}
 		},
 		"vscode-languageserver-textdocument": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
-			"integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+			"integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
 			"dev": true
 		},
 		"vscode-languageserver-types": {
@@ -6647,9 +6598,9 @@
 			"dev": true
 		},
 		"vscode-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.6.tgz",
-			"integrity": "sha512-fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+			"integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
 			"dev": true
 		},
 		"which": {
@@ -6671,6 +6622,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"yaml": {
 			"version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,18 @@
 		"Michael Leahy <support@typhonjs.io> (https://github.com/typhonrt)"
 	],
 	"dependencies": {
-		"@typhonjs-fvtt/runtime": "^0.0.21",
-		"@typhonjs-fvtt/svelte-standard": "^0.0.17",
+		"@typhonjs-fvtt/runtime": "^0.0.22",
+		"@typhonjs-fvtt/svelte-standard": "^0.0.18",
 		"chart.js": "^3.9.1",
-		"svelte": "^3.52.0",
-		"svelte-preprocess": "^4.10.7"
+		"svelte": "^3.55.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.18.0",
 		"@typhonjs-fvtt/eslint-config-foundry.js": "^0.8.0",
 		"eslint": "^8.26.0",
 		"eslint-config-arcanist": "^1.5.0",
-		"vite": "^3.2.2"
+		"svelte-preprocess": "^5.0.1",
+		"vite": "^4.1.1"
 	},
 	"browserslist": [
 		">5%",

--- a/src/store/mccSessionStorage.js
+++ b/src/store/mccSessionStorage.js
@@ -1,3 +1,3 @@
-import { SessionStorage } from "@typhonjs-fvtt/runtime/svelte/store";
+import { TJSSessionStorage } from "@typhonjs-fvtt/runtime/svelte/store";
 
-export const mccSessionStorage = new SessionStorage();
+export const mccSessionStorage = new TJSSessionStorage();

--- a/src/view/ModuleCompatibilityCheckerShell.svelte
+++ b/src/view/ModuleCompatibilityCheckerShell.svelte
@@ -18,7 +18,7 @@
 
 	export let elementRoot;
 
-	const { application } = getContext("external");
+	const { application } = getContext("#external");
 
 	// Get a store that is synchronized with session storage
 	const stateStore = mccSessionStorage.getStore(`mcc.appState`);

--- a/src/view/external/PatreonButton.svelte
+++ b/src/view/external/PatreonButton.svelte
@@ -2,6 +2,7 @@
 import { localize } from "@typhonjs-fvtt/runtime/svelte/helper";
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <span class="tag patreon" on:click={() => window.open("https://www.patreon.com/bePatron?u=15896855", "_blank")}>
 	<i class="fab fa-patreon" />
 	{localize("mcc.patreon")}

--- a/src/view/pie/PieChartLegend.svelte
+++ b/src/view/pie/PieChartLegend.svelte
@@ -9,16 +9,20 @@
 
 <section>
 	{#each $statuses as status, i (status.key)}
+		<!-- svelte-ignore a11y-click-events-have-key-events -->
 		<div class="entry" class:line-through={!status.value} on:click={() => statuses.toggleVisible(status.key)}>
 			<span style:background-color={$pieData.datasets[0].backgroundColor[i]}>{$pieData.datasets[0].data[i]} / {$spreadsheetStore.index.length}</span>
+			<!-- svelte-ignore a11y-missing-attribute -->
 			<a>{$pieData.labels[i]}</a>
 		</div>
 	{/each}
 	<hr />
 	<div class="links">
+		<!-- svelte-ignore a11y-missing-attribute a11y-click-events-have-key-events -->
 		<a on:click={statuses.setCompatibleVisible}>
 			<i class="fas fa-thumbs-up" /> {localize("mcc.showCompatible")}
 		</a>
+		<!-- svelte-ignore a11y-missing-attribute a11y-click-events-have-key-events -->
 		<a on:click={() => spreadsheetStore.resetFilters()}>
 			<i class="fas fa-trash" /> {localize("mcc.resetFilters")}
 		</a>

--- a/src/view/table/Controls.svelte
+++ b/src/view/table/Controls.svelte
@@ -57,6 +57,7 @@
 
 <nav>
 	<!-- TODO: link elements with id -->
+	<!-- svelte-ignore a11y-label-has-associated-control -->
 	<label>{localize("mcc.selectVersion")}</label>
 	<TJSSelect {select} />
 

--- a/src/view/table/Rows.svelte
+++ b/src/view/table/Rows.svelte
@@ -26,19 +26,19 @@
 					{
 						label: "mcc.packageListingURL",
 						icon: "fas fa-external-link",
-						onclick: () => window.open(`https://foundryvtt.com/packages/${linkData.id}`, "_blank"),
+						onPress: () => window.open(`https://foundryvtt.com/packages/${linkData.id}`, "_blank"),
 					},
 					{
 						label: "mcc.foundryHubURL",
 						icon: "fas fa-external-link",
 						image: "https://www.foundryvtt-hub.com/wp-content/uploads/2021/08/foundryhublogo4-verysmall.webp",
-						onclick: () => window.open(`https://www.foundryvtt-hub.com/package/${linkData.id}`, "_blank"),
+						onPress: () => window.open(`https://www.foundryvtt-hub.com/package/${linkData.id}`, "_blank"),
 					},
 					{
 						label: "mcc.bazaarURL",
 						icon: "fas fa-external-link",
 						image: "https://forge-vtt.com/images/the-forge-logo-48x48.png",
-						onclick: () => window.open(`https://forge-vtt.com/bazaar/package/${linkData.id}`, "_blank"),
+						onPress: () => window.open(`https://forge-vtt.com/bazaar/package/${linkData.id}`, "_blank"),
 					}
 				);
 			}
@@ -47,7 +47,7 @@
 				items.push({
 					label: "mcc.projectURL",
 					icon: "fas fa-code",
-					onclick: () => window.open(linkData.url, "_blank"),
+					onPress: () => window.open(linkData.url, "_blank"),
 				});
 			}
 

--- a/styles/init.scss
+++ b/styles/init.scss
@@ -1,3 +1,9 @@
+// Provides blue text shadow for package context menu.
+#mmc-package-menu {
+	--tjs-default-popup-background: hsl(220, 30%, 20%);
+	--tjs-default-text-shadow-focus-hover: 0 0 8px blue;
+}
+
 // Unfortunately there are several game systems out there that use `!important` to override styles
 #mcc {
 	accent-color: var(--mcc-medium-color);
@@ -12,11 +18,14 @@
 
 	--tjs-action-ripple-background: linear-gradient(64.5deg, var(--mcc-medium-color) 40%, var(--mcc-light-color) 60% );
 
+	--tjs-default-text-shadow-focus-hover: 0 0 8px blue;
+	--tjs-default-popup-background: var(--mcc-dark-color);
 	--tjs-input-text-padding: 0 0.25em;
 	--tjs-input-placeholder-color: hsl(50deg 15% 30%);
 	--tjs-icon-button-background: hsl(50deg 10% 80%);
 	--tjs-icon-button-background-hover: hsl(50deg 10% 75%);
 	--tjs-icon-button-background-selected: hsla(220, 70%, 60%, 0.2);
+	--tjs-select-option-background: var(--mcc-medium-color);
 
 	.window-content {
 		background: url(../../ui/parchment.jpg) !important;


### PR DESCRIPTION
Updates for all dependencies. 

Only minor changes necessary:

- `getContext("external")` to `getContext("#external")`.
- `SessionStorage` to `TJSSessionStorage`.
- `onclick` to `onPress` for TJSContextMenu menu item callbacks.
- Added relevant `svelte-ignore` statements in templates to not post warning messages. (removed old handler function in Vite config).
- Added a few default CSS variables to change context menu background to blue.